### PR TITLE
fix(oidc): always send OAuth state so PKCE provider callbacks validate

### DIFF
--- a/apps/server/src/auth/oidc.strategy.spec.ts
+++ b/apps/server/src/auth/oidc.strategy.spec.ts
@@ -128,6 +128,30 @@ describe("OidcStrategy", () => {
         expect(usersService.findOne).toHaveBeenCalledWith("john");
         expect(result).toEqual({ id: 1, name: "john", displayName: "John" });
     });
+
+    it("always includes a state parameter in the authorization request", () => {
+        // Authentik supports PKCE, so openid-client v6 would otherwise omit the
+        // state; we force one so the value Authentik echoes back validates.
+        const params = strategy.authorizationRequestParams(
+            {} as never,
+            {} as never
+        );
+
+        const state = params.get("state");
+        expect(typeof state).toBe("string");
+        expect(state).toBeTruthy();
+    });
+
+    it("generates a fresh state for each authorization request", () => {
+        const first = strategy
+            .authorizationRequestParams({} as never, {} as never)
+            .get("state");
+        const second = strategy
+            .authorizationRequestParams({} as never, {} as never)
+            .get("state");
+
+        expect(first).not.toEqual(second);
+    });
 });
 
 describe("oidcStrategyProvider", () => {

--- a/apps/server/src/auth/oidc.strategy.ts
+++ b/apps/server/src/auth/oidc.strategy.ts
@@ -1,14 +1,16 @@
 import { Injectable, Logger, UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
+import type { Request } from "express";
 import {
     Configuration,
     discovery,
     fetchUserInfo,
+    randomState,
     skipSubjectCheck,
     type TokenEndpointResponse,
     type TokenEndpointResponseHelpers,
 } from "openid-client";
-import { Strategy } from "openid-client/passport";
+import { type AuthenticateOptions, Strategy } from "openid-client/passport";
 import { User, UsersService } from "../users/users.service";
 import {
     DEFAULT_USERNAME_CLAIM,
@@ -48,6 +50,28 @@ export class OidcStrategy extends PassportStrategy(
             scope: config.scope,
             callbackURL: config.callbackUrl,
         });
+    }
+
+    // openid-client v6's passport Strategy only sends an OAuth `state`
+    // parameter when the authorization server lacks PKCE support (PKCE
+    // otherwise provides the CSRF protection state would). Authentik advertises
+    // PKCE, so the Strategy generates no state, yet Authentik still returns a
+    // `state` in the callback. oauth4webapi v3 then rejects the response with
+    // "unexpected \"state\" response parameter encountered" because no state was
+    // expected. Always including a state makes it round-trip and validate (and
+    // restores CSRF protection); the base Strategy stores any state present in
+    // the request params and checks it on the callback.
+    authorizationRequestParams<TOptions extends AuthenticateOptions>(
+        req: Request,
+        options: TOptions
+    ): URLSearchParams {
+        const params = new URLSearchParams(
+            super.authorizationRequestParams(req, options)
+        );
+        if (!params.has("state")) {
+            params.set("state", randomState());
+        }
+        return params;
     }
 
     async validate(tokens: OidcTokens): Promise<User> {


### PR DESCRIPTION
openid-client v6's passport Strategy only emits a state parameter when the authorization server lacks PKCE support. Authentik advertises PKCE, so no state was sent, but Authentik still returns a state in the callback. oauth4webapi v3 then rejects the response with "unexpected \"state\" response parameter encountered".

Override authorizationRequestParams to always include a state. The base Strategy stores any state present in the request params and validates it on the callback, so the round-tripped value now matches and CSRF protection via state is restored. This regression came from the openid-client v5->v6 upgrade; the OidcExceptionFilter (769231b) only made the previously-silent failure visible.